### PR TITLE
Support npm5

### DIFF
--- a/cmd.js
+++ b/cmd.js
@@ -105,7 +105,8 @@ function installShims (modulesToShim, done) {
             install = false
           }
         } else {
-          var existingVer = pkgJson.version
+          var existingVerNpm5 = (/\-([^\-]+)\.tgz/.exec(pkgJson.version) || [null, null])[1]
+          var existingVer = existingVerNpm5 || pkgJson.version
           if (semver.satisfies(existingVer, allShims[name])) {
             install = false
           }


### PR DESCRIPTION
npm5 installs modules and changes their `package.json`::`version` field to be something like 
```
  "version": "https://registry.npmjs.org/rn-nodeify/-/rn-nodeify-7.0.1.tgz",
```
instead of
```
  "version": "7.0.1",
```

This commit adds support for that first type of string but also supports npm4.